### PR TITLE
RM-37712 RM-37711 CEREBRAL-947 Cleanup old build files

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -7,7 +7,6 @@ size: small
 timeout: short
 
 run:
-  source: shipyard
   on-pull-request: true
   when-branch-name-is:
     - master


### PR DESCRIPTION
## Overview
This PR is to remove the remnants of the Smithy and Shipyard Build system, specifically to remove smithy.yaml and shipyard.yaml files and references.
We will not be following up on these prs, so please reach out in the Support: Build Tools hipchat room with any questions.
