### PR TITLE
SEC-18417 & SEC-18418: Address CVEs in ffi and rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    ffi (1.9.17)
+    ffi (1.9.24)
     haml (4.0.7)
       tilt
     hamster (3.0.0)
@@ -91,7 +91,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.0.5)
+    rack (2.0.6)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
Updating patch versions of libraries to address published CVEs documented in

https://jira.atl.workiva.net/browse/SEC-18417
https://jira.atl.workiva.net/browse/SEC-18418

@patrickofriel-wk  @dustinhiatt-wf  @charliestrawn-wf 