### PR TITLE
INFENG-7219 - K8s - Internal DNS - Pod Disruption Budget

### DIFF
--- a/helm/cerebral-docs/values.yaml
+++ b/helm/cerebral-docs/values.yaml
@@ -19,7 +19,7 @@ replicas: 1
 # iamRole: ''
 
 # The minimum number of available pods during updates
-minAvailable: 75%
+minAvailable: 50%
 
 # Autoscaling configuration, configures the horizontal pod autoscaler and pod disruption budget.
 # HPA: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
# Problem

There are a number of fixes INFRE would like to make at one time that require your help!

1. If your service uses internal DNS to reference another service by using the `<service_name>.service.workiva` query, we have modified it to use an updated query `<service_name>.workiva`.
   1. https://dev.workiva.net/docs/github/workiva/eks/docs/service_discovery for more information
2. Updating the helm chart pod disruption budget to support the rotation of 2 or more instances.
   1. **MANUAL INTERVENTION** If you are running one instance, we highly suggest running multiple, but if you can't please update the minAvailable to be 0%
3. **MANUAL INTERVENTION** We require your assistance in upgrading to the latest messaging-sdk and app-intelligence libraries, as the newest releases of these libraries also have updated internal DNS.

Minimum Versions:

- messaging-sdk == 2.35.0
- app_intelligence_java == 6.0.0
- app_intelligence_python == 5.0.0
- app_intelligence_go == 7.0.0

# Contact

We have programmatically made this PR and it is not perfect. Please assign an owner to this and ensure this gets merged as soon as possible.

If you have any questions please reach out to @ericlarssen-wf or #support-k8s-migration.
