### PR TITLE
CEREBRAL-1533 Fix up name collision in outline and add link to swagger json.

### DIFF
--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -1,4 +1,8 @@
-# Authentication
+# Code Generation
+
+Swagger is available to both view and download as JSON. You can find Swagger-UI [here](https://h.app.wdesk.com/s/cerebral/swagger-ui.html) and the JSON file [here](https://h.app.wdesk.com/s/cerebral/v2/api-docs).
+
+# Credentials
 
 The Workiva Developer API is secured using an OAuth 2.0 [Client Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.4) implementation. This authentication flow follows three steps:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -11,7 +11,7 @@ language_tabs:
   - go: Go
 toc_footers: []
 includes:
-  - authentication
+  - introduction
   - workflows
   - swagger
 search: true


### PR DESCRIPTION
Modifies the `authentication` title in the outline to prevent a collision with the auto generated swagger toc. Also adds a link to swagger ui and our json file.

@davidgiametta-wk 
@mattcoleman-wk 