### PR TITLE
CEREBRAL-1808 Add automatic swagger client generation.

### DIFF
--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -2,6 +2,12 @@
 
 Swagger is available to both view and download as JSON. You can find Swagger-UI [here](https://h.app.wdesk.com/s/cerebral/swagger-ui.html) and the JSON file [here](https://h.app.wdesk.com/s/cerebral/v2/api-docs).
 
+In order to aid developers, we've also auto-generated clients in the following 3 languages which can be downloaded as zip archives:
+
+* [Java](/s/cerebral-docs/generated/java/client.zip)
+* [C#](/s/cerebral-docs/generated/csharp/client.zip)
+* [Go](/s/cerebral-docs/generated/go/client.zip)
+
 # Credentials
 
 The Workiva Developer API is secured using an OAuth 2.0 [Client Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.4) implementation. This authentication flow follows three steps:

--- a/tool/generate_swagger.sh
+++ b/tool/generate_swagger.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+for i in java csharp go
+do
+    # this path tom-foolery is because if you don't cd into the root of the zip you are trying to create
+    # your path is fully representing in the generated archive...
+    # we don't want that, we just want it to be recursive but starting at the root path (which is why -j doesn't work)
+    java -jar swagger-codegen-cli-2.2.1.jar generate -i https://h.app.wdesk.com/s/cerebral/v2/api-docs -l $i -o source/generated/$i && \
+    cd source/generated/$i && \
+    zip -r client.zip ./* && \
+    cd ../../.. && \
+    mv source/generated/$i/client.zip . && \
+    rm -rf source/generated/$i && \
+    mkdir -p source/generated/$i && \
+    mv client.zip source/generated/$i/client.zip;
+done


### PR DESCRIPTION
Automatically generates client code for go, java, and c#. The python generator is not working correctly, some sort of camel -> snake case conversion issue. I have been able to get that to work correctly with swagger codegen 3+ so I assume it's a 2.x issue. I haven't tested any 3.x clients though so I'd prefer to separate this work as that will require separate verification.

@Workiva/scout-backend 