### PR TITLE
INFENG-9458: 🤖 Vertical Scaling Documentation

### DIFF
--- a/helm/cerebral-docs/values.yaml
+++ b/helm/cerebral-docs/values.yaml
@@ -60,6 +60,9 @@ environment:
 
 # Resources allocated to your container.
 # See: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+# Expect CPU requests/limits to be overridden at deploy time by RM pipelines.
+# For more information on how those calculations are made and set checkout the wiki.
+# https://wiki.atl.workiva.net/display/INF/Vertical+Scaling+Calculations
 resources:
    limits:
      cpu: 0.25


### PR DESCRIPTION
## What
As part of INFRE's effort to increase resource utilization and decrease AWS spending, we will be vertically scaling CPU requests and limits for products deployed to Kubernetes through RM Pipelines.

For every "Deploy Kubernetes Service" step in the pipelines we will be overriding the `resources.requests.cpu` and `resources.limits.cpu` deployment values for your helm chart. These values will be determined from historical CPU usage of your service in Datadog. 

```
resources.limits.cpu   = max cpu usage * 1.3 + 1.0
resources.requests.cpu = avg cpu usage * 5.0
resources.requests.cpu = min(resources.limits.cpu, resources.requests.cpu)
```

The maximum value for each will be 8 cores and minimum will be 100 millicores.

Utilization as well as your current requests/limits can be found in [Datadog](https://app.datadoghq.com/dashboard/47z-y8v-snz/kubernetes-service-resource-allocation).  The determined values will also show up as a part of the deploy logs for your pipeline. (These values will be recalculated for each deploy)

You can find a forecast of the new projected requests and limits in [this spreadsheet](https://sandbox.wdesk.com/a/QWNjb3VudB8yMDAx/spreadsheet/952bb3541dba4473b1675ece12a13123).

## Timeline
Vertically scaling in the pipelines will be enabled on the following dates. Until then you’ll have the opportunity to opt-out of vertical scaling. At any point in time after the dates you’ll also be allowed to opt-out and rollback from vertical scaling.


| Clusters                                   | Date  |
|--------------------------------------------|-------|
| wk-dev, inf-dev, staging, pentest, sandbox | 11/4  |
| inf-tools, prod, prod-eu, demo             | 11/18 |


## What we need from you
We don’t expect drastic changes in code, but there are a couple things we would like teams to consider before the opt-out deadlines.

- [ ] Explicitly set the number of workers for your nats client in the go/java messaging sdk (at the moment concurrency is determined by the number of CPUs requested for your pod)
  * [Go Nats Client](https://github.com/Workiva/messaging-sdk/blob/master/lib/go/sdk/nats_client.go#L117)
  * [Java Nats Client](https://github.com/Workiva/messaging-sdk/blob/master/lib/java/sdk/src/main/java/com/workiva/messaging_sdk/NatsMessagingClient.java#L449)
  * Currently, the worker count is determined by your CPU request rounded up. (eg. 2500m or 2.5 rounds up to 3 workers)

- [ ] Adjust pod CPU autoscaling threshold if less than 75%
   * The calculation used by the HPA for determining utilization is `usage/requested`.  This means the average utilization for your pods will increase. This means spikes in CPU will be more likely to cause your service to horizontally scale up.
   * This parameter is located under `autoscaling` in the values.yaml file of your chart.
- [ ] Adjust memory limits/requests if possible
   * Since we’ve decided against vertically scaling memory we’d appreciate it if you’d consider lowering your memory limits and requests if possible.

## Opting Out
Some of you might be worried about the problems vertical scaling might bring.  It's our duty as developers to ensure a premium experience for our customers. If you determine vertical scaling will negatively impact your service please take the time to opt-out.  We understand this won't be a perfect fit for every product.

To opt-out go to your service’s pipeline template and look for the the “Deploy Kubernetes” steps. For each Kubernetes deploy you can modify each step to either enable or disable vertical scaling. Typically there’s a step for each environment, which will give you the ability to dictate scaling per cluster. To edit click on the step and click on the cog wheel which pops up.  For example...

![https://i.imgur.com/RFjwzXH.png](https://i.imgur.com/RFjwzXH.png)

From here you can change the form to configure the step. Specifically to turn off vertical scaling you need to change the “Optimize resource requests/limits” to “No”. This will prevent the pipelines from changing CPU resources values at deploy time.

![https://i.imgur.com/583BoTt.png](https://i.imgur.com/583BoTt.png)

At any point you can change this value and rollback from vertical scaling. Doing so will revert any vertical scaling changes previously made by the pipeline (once deployed).

For more info checkout our [blog post](https://w-dev-blog.appspot.com/posts/2019/10/04/resource-utilization/) on the topic.  If you have any questions please reach out to me or the `#support-kubernetes` slack room. For any immediate support issues reach out to the `#support-infre` channel.

