### PR TITLE
INFENG-9716: 🤖 Add Pod Labels

### DIFF
--- a/helm/cerebral-docs/templates/deployment.yaml
+++ b/helm/cerebral-docs/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "template.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -18,6 +21,9 @@ spec:
       labels:
         app: {{ template "template.name" . }}
         release: {{ .Release.Name }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         # consul.*/ annotations will register your service in consul
         # for service discovery.

--- a/helm/cerebral-docs/values.yaml
+++ b/helm/cerebral-docs/values.yaml
@@ -109,3 +109,7 @@ readinessProbe:
 #  periodSeconds: 10
 #  timeoutSeconds: 10
 #  failureThreshold: 3
+
+labels:
+  automation.org-group: wdata
+  servicecatalog.owner: data-prep


### PR DESCRIPTION
## What
In an effort to help INFRE categorize and establish ownership of pods in Kubernetes we are attaching specialized labels to pods. These labels should reflect the taxonomy and team responsible for the Helm charts in this repo. To see the complete taxonomy checkout [this chart](https://docs.google.com/drawings/d/11Qieha0XN4AP5rSufLR5OD6d5ej2OSce1fGZGskRdiM/edit).

If the purposed ownership in this PR is incorrect, please let us know so we can update it!

For any questions and concerns please reach out to us in the `#proj-aws-tagging` slack channel.

