### PR TITLE
CEREBRAL-3982 Redirect old docs site to new developers readme

### DIFF
--- a/helm/cerebral-docs/templates/ingress.yaml
+++ b/helm/cerebral-docs/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.rules -}}
+# Redirect ingress destined for /s/cerebral-docs* to the new developers.workiva.com site
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -10,28 +10,51 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: {{ $.Values.ingress.rewritePathPrefix }}{{ $.Values.ingress.rewritePlaceHolder }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($uri ~ ^/s/cerebral-docs(.*)$) {
+        return 301 https://developers.workiva.com/workiva-wdata/reference;
+      }
 spec:
   tls:
-  {{- range $rule := .Values.ingress.rules }}
     - hosts:
-      - {{ $rule.subDomain }}.{{ required "ingress.clusterDomain is required" $.Values.ingress.clusterDomain }}
-      secretName: {{ default "default-ingress-cert" $rule.tlsSecret }}
-  {{- end }}
+      - h.{{ required "ingress.clusterDomain is required" .Values.ingress.clusterDomain }}
+      secretName: "default-ingress-cert"
   rules:
-  {{- range $rule := .Values.ingress.rules }}
-    - host: {{ $rule.subDomain }}.{{ $.Values.ingress.clusterDomain }}
+    - host: h.{{ .Values.ingress.clusterDomain }}
       http:
         paths:
-        {{- range $backend := $rule.backends }}
           - backend:
               serviceName: {{ template "template.fullname" $ }}
-              servicePort: {{ $backend.port }}
-            {{- if or $rule.pathPrefix $backend.path }}
-              {{- $prefix := default "" $rule.pathPrefix }}
-              {{- $path := default "" $backend.path }}
-            path: {{ clean (printf "/%s/%s" $prefix $path) }}
-            {{- end }}
-        {{- end}}
-  {{- end }}
-{{- end }}
+              servicePort: 8000
+            path: /s/cerebral-docs/(.*)
+# Redirect ingress destined for /s/wdata-docs* to the new developers.workiva.com site
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "template.fullname" . }}
+  labels:
+    app: {{ template "template.name" . }}
+    chart: {{ template "template.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($uri ~ ^/s/wdata-docs/prep(.*)$) {
+        return 301 https://developers.workiva.com/workiva-wdata/reference;
+      }
+spec:
+  tls:
+    - hosts:
+      - h.{{ required "ingress.clusterDomain is required" .Values.ingress.clusterDomain }}
+      secretName: "default-ingress-cert"
+  rules:
+    - host: h.{{ .Values.ingress.clusterDomain }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ template "template.fullname" $ }}
+              servicePort: 8000
+            path: /s/wdata-docs/prep/(.*)

--- a/helm/cerebral-docs/templates/ingress.yaml
+++ b/helm/cerebral-docs/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "template.fullname" . }}
+  name: {{ template "template.fullname" . }}-cerebral-docs
   labels:
     app: {{ template "template.name" . }}
     chart: {{ template "template.chart" . }}
@@ -33,7 +33,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "template.fullname" . }}
+  name: {{ template "template.fullname" . }}-wdata-docs
   labels:
     app: {{ template "template.name" . }}
     chart: {{ template "template.chart" . }}

--- a/helm/cerebral-docs/templates/ingress.yaml
+++ b/helm/cerebral-docs/templates/ingress.yaml
@@ -28,6 +28,7 @@ spec:
               serviceName: {{ template "template.fullname" $ }}
               servicePort: 8000
             path: /s/cerebral-docs/(.*)
+---
 # Redirect ingress destined for /s/wdata-docs* to the new developers.workiva.com site
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/helm/cerebral-docs/values.yaml
+++ b/helm/cerebral-docs/values.yaml
@@ -36,23 +36,13 @@ autoscaling:
 
 # Ingress configuration
 # See: https://kubernetes.io/docs/concepts/services-networking/ingress/
+# NOTE: Ingress for this repo now just redirects /s/cerebral-docs/ and
+# /s/wdata-docs/prop/ to the new developers.workiva.net site.
+# These rules are hardcoded in the ingress.yaml file, and the only input
+# from here is the clusterDomain.
 ingress:
   # Base domain for the cluster (ex. wk-dev.wdesk.org, app.wdesk.org).
   clusterDomain: ''
-  rewritePlaceHolder: /$1
-  rewritePathPrefix: /s/cerebral-docs
-  rules:
-    # Rules for h.<clusterDomain> (ex. h.wk-dev.wdesk.org).
-    - subDomain: h
-      pathPrefix: /s/cerebral-docs/(.*)
-      backends:
-        - path: /
-          port: 8000
-    - subDomain: h
-      pathPrefix: /s/wdata-docs/prep/(.*)
-      backends:
-        - path: /
-          port: 8000
 
 # Environment variables.
 environment:


### PR DESCRIPTION
###### Overview:
Need to redirect the old doc sites to the new readme site.

The basics of this PR are based on https://gist.github.com/sandcastle/810dee50e96a8214519ba0989f6af964

The gist of this redirect is the ability to provide nginx configuration for a specific ingress rule. The `nginx.ingress.kubernetes.io/configuration-snippet` annotation allows "additional configuration to the NGINX location" https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#configuration-snippet

We then give that a rule to redirect to the new developers site if the URI matches `^/s/cerebral-docs(.*)$` or `^/s/wdata-docs/prep(.*)$`

I also included the `rewrite-target: /$1` annotation as I believe that allows us to pass-through any extra url things like ##code-generation

###### Reviewers:
@Workiva/scout-team